### PR TITLE
Add testing for delete and 404 on post

### DIFF
--- a/app.js
+++ b/app.js
@@ -109,15 +109,19 @@ app.patch('/api/v1/projects/:id', (request, response) => {
   for (let requiredParameter of ['name']) {
     if (!request.body[requiredParameter]) {
       return response.status(422).send({
-        error: `Expected format { name: <String>. You are missing a ${requiredParameter} property}`
+        error: `Expected format { name: <String>. You are missing a ${requiredParameter} property }`
       });
     }
     database('projects')
       .where('id', request.params.id)
       .update({ ...request.body })
-      .then(() =>
-        response.status(202).json({ id: id})
-      )
+      .then(project => {
+        if(project.length) {
+          response.status(202).json({ id: id});
+        } else {
+          response.status(404).json(`No project with the id: ${id} found`);
+        }
+      })
       .catch(error => response.status(500).json({ error }));
   }
 });
@@ -127,17 +131,39 @@ app.patch('/api/v1/palettes/:id', (request, response) => {
   for (let requiredParameter of ['name']) {
     if (!request.body[requiredParameter]) {
       return response.status(422).send({
-        error: `Expected format { name: <String>. You are missing a ${requiredParameter} property}`
+        error: `Expected format { name: <String>. You are missing a ${requiredParameter} property }`
       });
     }
     database('palettes')
       .where('id', request.params.id)
       .update({ ...request.body })
-      .then(() =>
-        response.status(202).json({ id: id})
-      )
+      .then(palette => {
+        if(palette.length) {
+          response.status(202).json({ id: id});
+        } else {
+          response.status(404).json(`No palette with the id: ${id} found`);
+        }
+      })
       .catch(error => response.status(500).json({ error }));
   }
+});
+
+app.delete('/api/v1/palettes/:id', (request, response) => {
+  const { id } = request.params;
+
+  database('palettes')
+    .where({ id: id })
+    .del()
+    .then(res => {
+      if(res) {
+        response.status(200).json(`Palette ${id} has been deleted`);
+      } else {
+        response.status(404).json(`Could not find palette with the id of: ${id}`);
+      }
+    })
+    .catch(error => {
+      response.status(500).json({ error });
+    })
 });
 
 

--- a/app.test.js
+++ b/app.test.js
@@ -132,8 +132,26 @@ describe('Server', () => {
 
       expect(project.status).toBe(202);
       expect(postPatchProject.name).toEqual(project1[2].name)
-    })
-  })
+    });
+
+    it('should return a 422 status and the missing information from the body', async () => {
+      const invalidParam = { nombre: 'Bob' };
+
+      const project = await request(app).patch('/api/v1/projects/1').send(invalidParam);
+
+      expect(project.status).toBe(422);
+      expect(project.body.error).toBe('Expected format { name: <String>. You are missing a name property }');
+    });
+
+    it('should return a 404 status and a message stating no project found', async () => {
+      const invalidId = -1;
+      const param = { name: 'Valid project name'}
+      const response = await request(app).patch(`/api/v1/projects/${invalidId}`).send(param);
+
+      expect(response.status).toBe(404);
+      expect(response.body).toEqual(`No project with the id: ${invalidId} found`);
+    });
+  });
 
   describe('PATCH /api/v1/palettes/:id', () => {
     it('should return a 202 status and return the modified palette', async () => {
@@ -144,10 +162,64 @@ describe('Server', () => {
       const postPatchPalette = {
         name: 'Very New Name',
       }
-      const project = await request(app).patch('/api/v1/palettes/1').send(postPatchPalette)
+      const palette = await request(app).patch('/api/v1/palettes/1').send(postPatchPalette)
 
-      expect(project.status).toBe(202);
+      expect(palette.status).toBe(202);
       expect(postPatchPalette.name).toEqual('Very New Name')
+    });
+
+    it('should return a 422 status and the missing information from the body', async () => {
+      const invalidParam = { nombre: 'Bob' };
+
+      const palette = await request(app).patch('/api/v1/palettes/1').send(invalidParam);
+
+      expect(palette.status).toBe(422);
+      expect(palette.body.error).toBe('Expected format { name: <String>. You are missing a name property }');
+    });
+
+    it('should return a 404 status and a message stating no palette found', async () => {
+      const invalidId = -1;
+      const param = { name: 'Valid project name'}
+      const response = await request(app).patch(`/api/v1/palettes/${invalidId}`).send(param);
+
+      expect(response.status).toBe(404);
+      expect(response.body).toEqual(`No palette with the id: ${invalidId} found`);
+    });
+  });
+
+  describe('DELETE /api/v1/palettes/:id', () => {
+    it('should return a 200 status code and the id of the deleted palette', async () => {
+      const palettes = await database('palettes').select();
+      const palette = palettes[0];
+      const paletteId = palette.id;
+
+      const response = await request(app).delete(`/api/v1/palettes/${paletteId}`);
+
+      expect(response.status).toBe(200);
+      expect(response.body).toEqual(`Palette ${paletteId} has been deleted`);
+    });
+
+    it('should reduce the size of the database if the deletion was successful', async () => {
+      const palettes = await database('palettes').select();
+      const palette = palettes[0];
+      const paletteId = palette.id;
+
+      expect(palettes.length).toEqual(3);
+
+      const response = await request(app).delete(`/api/v1/palettes/${paletteId}`);
+
+      const deletedPalettes = await database('palettes').select();
+
+      expect(deletedPalettes.length).toEqual(2);
+    })
+
+    it('should return a 404 status code if there is no palette with the matching id and the corresponding error message', async () => {
+      const invalidId = -1;
+
+      const response = await request(app).delete(`/api/v1/palettes/${invalidId}`);
+
+      expect(response.status).toBe(404);
+      expect(response.body).toBe('Could not find palette with the id of: -1');
     })
   })
 }); 


### PR DESCRIPTION
# Description

This PR contains the test and the functionality for happy and sad paths regarding the delete method.
It also has added in the 404 errors to patch on both projects and palettes as well as the accompanying tests.

Fixes # 
Lack of 404 in the patch methods.

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

All tests have been run and passes using Jest (except for the weird things that happen with the ghosts).

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
